### PR TITLE
fix: update scope of `validate` variable

### DIFF
--- a/implementations/sample/cli.js
+++ b/implementations/sample/cli.js
@@ -215,13 +215,14 @@ properties:
 
 const validateSchema = async (claimset) => {
   const schemas = {}
+  let validate = { errors: `claimset.type must include "${VC_RDF_CLASS}" or "${VP_RDF_CLASS}"` };
   let is_base_media_type_valid = false;
   if (isVC(claimset)){
-    const validate = ajv.compile(yaml.load(validateVC))
+    validate = ajv.compile(yaml.load(validateVC))
     is_base_media_type_valid = validate(claimset)
   }
   if (isVP(claimset)){
-    const validate = ajv.compile(yaml.load(validateVP))
+    validate = ajv.compile(yaml.load(validateVP))
     is_base_media_type_valid = validate(claimset)
   }
   if (!is_base_media_type_valid) {


### PR DESCRIPTION
This PR updates the scope of the `validate` variable in the `validateSchema` function so that it is available in case `is_base_media_type_valid` is false and the `errors` property needs to be accessed.

A default value with an error is also added to cover the case where the claimset is neither a VC or a VP.